### PR TITLE
Improving security and error messages

### DIFF
--- a/ONVAULT
+++ b/ONVAULT
@@ -21,4 +21,5 @@ if curl -s "${VAULT_URI}/_ping"; then
 else
   echo " ---> [Dockito Vault] ERROR: Start the dockito/vault container before using ONVAULT!"
   echo " ---> [Dockito Vault] ex: docker run -d -p 172.17.42.1:14242:3000 -v ~/.ssh:/vault/.ssh dockito/vault"
+  exit 1
 fi

--- a/ONVAULT
+++ b/ONVAULT
@@ -3,19 +3,22 @@
 # signals bash to stop execution on any fail
 set -e
 
-mkdir -p ~/.ssh/
+# allow overriding default VAULT_URI at runtime
+: ${VAULT_URI:=http://172.17.42.1:14242}
 
-echo " ---> [Dockito Vault] Downloading private keys..."
+if curl -s "${VAULT_URI}/_ping"; then
+  echo " ---> [Dockito Vault] Downloading private keys..."
 
-TEMP_FILE=`mktemp -q /tmp/ssh.XXXXXX`
-curl -o $TEMP_FILE http://172.17.42.1:14242/ssh.tgz
-tar xzf $TEMP_FILE -C ~/.ssh/
-chown `whoami` ~/.ssh/*
+  mkdir -p ~/.ssh/
+  curl "${VAULT_URI}/ssh.tgz" | tar -C ~/.ssh/ -zxf -
+  chown `whoami` ~/.ssh/*
 
-echo " ---> [Dockito Vault] Executing command: $@"
+  echo " ---> [Dockito Vault] Executing command: $@"
+  eval $@
 
-eval $@
-
-echo " ---> [Dockito Vault] Removing private keys..."
-
-rm -rf ~/.ssh/*
+  echo " ---> [Dockito Vault] Removing private keys..."
+  rm -rf ~/.ssh/*
+else
+  echo " ---> [Dockito Vault] ERROR: Start the dockito/vault container before using ONVAULT!"
+  echo " ---> [Dockito Vault] ex: docker run -d -p 172.17.42.1:14242:3000 -v ~/.ssh:/vault/.ssh dockito/vault"
+fi

--- a/ONVAULT
+++ b/ONVAULT
@@ -10,7 +10,7 @@ if curl -s "${VAULT_URI}/_ping"; then
   echo " ---> [Dockito Vault] Downloading private keys..."
 
   mkdir -p ~/.ssh/
-  curl "${VAULT_URI}/ssh.tgz" | tar -C ~/.ssh/ -zxf -
+  curl -s "${VAULT_URI}/ssh.tgz" | tar -C ~/.ssh/ -zxf -
   chown `whoami` ~/.ssh/*
 
   echo " ---> [Dockito Vault] Executing command: $@"


### PR DESCRIPTION
- Removes the leftover `TEMP_FILE` tarball containing private ssh keys.
- Adds better error messaging in case the user hasn't yet started the vault container.
- Allows overriding the vault URI at runtime (keeps default of `http://172.17.42.1:14242`)

@pirelenito This is a _CRITICAL_ security fix. Please merge, release, and update docs as soon as possible.
