### PR TITLE
Problem when running docker-compose up vault on a clean checkout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 vault:
   build: .
   volumes:
-    - .:/usr/src/app
     - ~/.ssh:/vault/.ssh
   ports:
     - 172.17.42.1:14242:3000


### PR DESCRIPTION
If you do

```
git clone https://github.com/dockito/vault.git
cd vault
docker-compose up vault
```

it doesn't work because the volume mount replaces the app (and node_modules created by npm install) inside the docker image. What was the reason to include . as volume?
