### PR TITLE
updating ONVAULT to use dynamic docker bridge ip

### DIFF
--- a/ONVAULT
+++ b/ONVAULT
@@ -3,8 +3,10 @@
 # signals bash to stop execution on any fail
 set -e
 
+: ${VAULT_HOST:=$(ip route|awk '/default/{print $3}')}
+
 # allow overriding (probably trough Docker Link) default VAULT_PORT at runtime
-: ${VAULT_PORT:=tcp://172.17.42.1:14242}
+: ${VAULT_PORT:=tcp://${VAULT_HOST}:14242}
 
 # allow overriding default VAULT_URI at runtime
 : ${VAULT_URI:=${VAULT_PORT/tcp/http}}
@@ -47,6 +49,6 @@ if curl -s "${VAULT_URI}/_ping"; then
   rm -rf ~/.ssh/*
 else
   log "ERROR: Start the dockito/vault container before using ONVAULT!"
-  log "ex: docker run -d -p 172.17.42.1:14242:3000 -v ~/.ssh:/vault/.ssh dockito/vault"
+  log "ex: docker run -d -p ${VAULT_HOST}:14242:3000 -v ~/.ssh:/vault/.ssh dockito/vault"
   exit 1
 fi


### PR DESCRIPTION
Docker v1.10 recently changed their default bridge IP to `172.17.0.1`. This change (and you might update the docs to reflect) allows ONVAULT to find the bridge IP inside the container, and even suggests how to invoke it with that IP.
