### PR TITLE
Switching base image to `mhart/alpine-node:0.10`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
-FROM node:0.10.38-onbuild
+FROM mhart/alpine-node:0.10
 
 RUN mkdir -p /vault
 
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app
+RUN npm install
+COPY . /usr/src/app
+
 EXPOSE 3000
 VOLUME /vault
+
+CMD [ "npm", "start" ]

--- a/ONVAULT
+++ b/ONVAULT
@@ -3,8 +3,10 @@
 # signals bash to stop execution on any fail
 set -e
 
+: ${VAULT_HOST:=$(ip route|awk '/default/{print $3}')}
+
 # allow overriding (probably trough Docker Link) default VAULT_PORT at runtime
-: ${VAULT_PORT:=tcp://172.17.42.1:14242}
+: ${VAULT_PORT:=tcp://${VAULT_HOST}:14242}
 
 # allow overriding default VAULT_URI at runtime
 : ${VAULT_URI:=${VAULT_PORT/tcp/http}}
@@ -47,6 +49,6 @@ if curl -s "${VAULT_URI}/_ping"; then
   rm -rf ~/.ssh/*
 else
   log "ERROR: Start the dockito/vault container before using ONVAULT!"
-  log "ex: docker run -d -p 172.17.42.1:14242:3000 -v ~/.ssh:/vault/.ssh dockito/vault"
+  log "ex: docker run -d -p ${VAULT_HOST}:14242:3000 -v ~/.ssh:/vault/.ssh dockito/vault"
   exit 1
 fi


### PR DESCRIPTION
706mb is too big for vault. Let's maybe trim it down a bit?

```
REPOSITORY                               TAG                 IMAGE ID            CREATED             SIZE
dockito/vault                            alpine              bb86299d4550        37 seconds ago      31.43 MB
dockito/vault                            latest              04556058e17e        3 months ago        706 MB
```

Includes (because I suck at git) my other PR for auto-discovering the docker bridge IP to support the subnet changes introduced in docker 1.10
