### PR TITLE
Fix tilde expansion issue on alpine 3.3 with bash 4.3.

### DIFF
--- a/ONVAULT
+++ b/ONVAULT
@@ -43,7 +43,7 @@ if curl -s "${VAULT_URI}/_ping"; then
 
   # creating backup of existing ssh directory
   if [[ -n "$ssh_backup_enabled" ]]; then
-    tmp_ssh_vault="~/.vault-backup-ssh-$(date +%s)"
+    tmp_ssh_vault=~/".vault-backup-ssh-$(date +%s)"
     mkdir $tmp_ssh_vault
     cp -r ~/.ssh/* $tmp_ssh_vault
   fi


### PR DESCRIPTION
On alpine 3.3 using bash 4.3, "~/.vault-backup-ssh-$(date +%s)" doesn't expand and remains a literal tilde. This changes fixes that, while still hopefully working on other versions (although I haven't tested any other combos)
